### PR TITLE
changed type specifier for coercing ratio to float

### DIFF
--- a/writer.lisp
+++ b/writer.lisp
@@ -26,7 +26,7 @@
   (with-output-to-string (stream)
     (write number :stream stream :pretty nil)))
 (defmethod to-json ((ratio ratio))
-  (to-json (coerce ratio 'float)))
+  (to-json (coerce ratio *read-default-float-format*)))
 
 (defmethod to-json ((list list))
   (let ((*print-pretty* nil)) ;; *pretty-print* makes printing very slow, internal json objects needn't have this


### PR DESCRIPTION
As the ".. printer uses _read-default-float-format_ to guide the choice
of exponent markers when printing floating-point numbers .."
(see: http://www.lispworks.com/documentation/HyperSpec/Body/v_rd_def.htm#STread-default-float-formatST),
using _read-default-float-format_ is a sensible default when converting ratios to floats.  
