### PR TITLE
Avoid using e notation because Lisp, JS and JSON numeral syntaxes are

### DIFF
--- a/tests/writer.lisp
+++ b/tests/writer.lisp
@@ -16,6 +16,10 @@
       (is (string= (to-json '(:obj ("bar" . 101/10)))
                    "{\"bar\":10.1}")
           "Could fail on some systems due to rounding errors")
+      (is (string= (to-json '(:obj ("bar" . 1.e8)))
+                   "{\"bar\":100000000.0}")
+          "Large floats should not be in e notation due to
+           inconsistency in JSON numeral syntax")
       (is (string= (to-json '(:obj ("baz" "bang" "bing" 10 "bonzo")))
                    "{\"baz\":[\"bang\",\"bing\",10,\"bonzo\"]}")
           "list should expand to a json array")
@@ -33,6 +37,10 @@
       (is (string= (to-json* '(:obj ("bar" . 101/10)))
                    "{\"bar\":10.1}")
           "Could fail on some systems due to rounding errors")
+      (is (string= (to-json* '(:obj ("bar" . 1.e8)))
+                   "{\"bar\":100000000.0}")
+          "Large floats should not be in e notation due to
+           inconsistency in JSON numeral syntax")
       (is (string= (to-json* '(:obj ("baz" "bang" "bing" 10 "bonzo")))
                    "{\"baz\":[\"bang\",\"bing\",10,\"bonzo\"]}")
           "list should expand to a json array")

--- a/writer.lisp
+++ b/writer.lisp
@@ -52,8 +52,7 @@
   (to-json (coerce ratio 'float)))
 (defmethod to-json ((float float))
   (let ((*read-default-float-format* (type-of float)))
-    (with-output-to-string (stream)
-      (write float :stream stream :pretty nil))))
+    (format nil "~F" float)))
 
 (defmethod to-json ((list list))
   (let ((*print-pretty* nil)) ;; *pretty-print* makes printing very slow, internal json objects needn't have this
@@ -124,7 +123,9 @@
 (defun write-number* (object output)
   (declare (type number object)
            (type stream output))
-  (write object :stream output))
+  (typecase object
+    (float (format output "~F" object))
+    (otherwise (write object :stream output))))
 
 (defun write-string* (object output)
   (declare (type string object)


### PR DESCRIPTION
Unlike Lisp and JavaScript, JSON numeral syntax doesn't allow decimal points without decimal digits:

![number](https://cloud.githubusercontent.com/assets/3055134/5315346/99235fb4-7c7c-11e4-9e28-fc83d9acd980.gif)
(from http://www.json.org/fatfree.html)

``` javascript
% node
> 1.e8
100000000
> JSON.parse("[1e8]")
[ 100000000 ]
> JSON.parse("[1.e8]")
SyntaxError: Unexpected token e
```

I think the easiest and safest solution is to prevent JSOWN from using e notation when serialising floats.
