### PR TITLE
Work around ECL bug to parse even-sized strings.

### DIFF
--- a/reader.lisp
+++ b/reader.lisp
@@ -246,7 +246,10 @@
   (mark-buffer buffer)
   (decr-char buffer)
   (let ((unescape-count 0))
-    (loop do (incf (the fixnum unescape-count) (the fixnum (next-char/i buffer)))
+    ;; Work around ECL bug. See https://gitlab.com/embeddable-common-lisp/ecl/issues/401
+    (loop do (incf #-ecl (the fixnum unescape-count)
+                   #+ecl unescape-count
+                   (the fixnum (next-char/i buffer)))
        until (eql (current-char buffer) last-char))
     (if (> unescape-count 0)
         (unescape-string/count buffer unescape-count)


### PR DESCRIPTION
Following up on #18.

I had to fork it locally to make some progress anyway, might as well share the code. :slightly_smiling_face: 