### PR TITLE
added surrogate pairs to reader

### DIFF
--- a/tests/reader.lisp
+++ b/tests/reader.lisp
@@ -68,3 +68,7 @@
         (is (equal (parse-with-container "{\"foo\":\"bar\",\"baz\":\"bang\",\"bing\":\"bang\"}" container)
                    '(:obj ("foo" . "bar") ("baz" . "bang") ("bing" . "bang")))
             "All elements")))
+
+(test unicode-chars
+  (is (equal (parse "{\"λlambda\":\"\\ud83d\\udca9poop\"}")
+             '(:obj ("λlambda" . "💩poop")))))

--- a/tests/reader.lisp
+++ b/tests/reader.lisp
@@ -70,5 +70,11 @@
             "All elements")))
 
 (test unicode-chars
-  (is (equal (parse "{\"λlambda\":\"\\ud83d\\udca9poop\"}")
-             '(:obj ("λlambda" . "💩poop")))))
+  (is (equal (parse "{\"\\u03BBlambda\":\"\\ud83d\\udca9poop\"}")
+             '(:obj ("λlambda" . "💩poop"))))
+
+  (is (equal (parse "{\"lambda\\u03BB\":\"poop\\ud83d\\udca9\"}")
+             '(:obj ("lambdaλ" . "poop💩"))))
+
+  (is (equal (parse "{\"lambda\\u03BBlambda\":\"poop\\ud83d\\udca9poop\"}")
+             '(:obj ("lambdaλlambda" . "poop💩poop")))))


### PR DESCRIPTION
I have attempted to add surrogate pairs to the reader but you can just ignore these changes if you want, I did this mostly for fun.

added small test to test surrogate pairs and normally escaped unicodes

changed unescape-string/count to decode surrogate paris

changed next-char/ and next-char/i to count surrogate pairs as one character